### PR TITLE
feat(debug): add start without debugging button

### DIFF
--- a/src/CodingWithCalvin.LaunchyBar/Models/LaunchyBarConfiguration.cs
+++ b/src/CodingWithCalvin.LaunchyBar/Models/LaunchyBarConfiguration.cs
@@ -73,6 +73,16 @@ public sealed class LaunchyBarConfiguration
                 },
                 new()
                 {
+                    Id = "start-without-debugging",
+                    Name = "Start Without Debugging",
+                    IconPath = "KnownMonikers.RunOutline",
+                    Type = LaunchItemType.VsCommand,
+                    Target = "Debug.StartWithoutDebugging",
+                    Position = LaunchItemPosition.Top,
+                    Order = 4
+                },
+                new()
+                {
                     Id = "terminal",
                     Name = "Terminal",
                     IconPath = "KnownMonikers.Console",

--- a/src/CodingWithCalvin.LaunchyBar/Services/DebugStateService.cs
+++ b/src/CodingWithCalvin.LaunchyBar/Services/DebugStateService.cs
@@ -61,6 +61,15 @@ public sealed class DebugStateService : IDisposable
             debugItem.IconPath = isDebugging ? "KnownMonikers.Stop" : "KnownMonikers.Run";
             debugItem.Name = isDebugging ? "Stop Debugging" : "Start Debugging";
         }
+
+        var startWithoutDebuggingItem = _configurationService.Configuration.Items
+            .FirstOrDefault(i => i.Id == "start-without-debugging" || i.Target == "Debug.StartWithoutDebugging");
+
+        if (startWithoutDebuggingItem != null)
+        {
+            startWithoutDebuggingItem.IconPath = isDebugging ? "KnownMonikers.Stop" : "KnownMonikers.RunOutline";
+            startWithoutDebuggingItem.Name = isDebugging ? "Stop Debugging" : "Start Without Debugging";
+        }
     }
 
     public void Dispose()

--- a/src/CodingWithCalvin.LaunchyBar/Services/LaunchService.cs
+++ b/src/CodingWithCalvin.LaunchyBar/Services/LaunchService.cs
@@ -71,9 +71,10 @@ public sealed class LaunchService : ILaunchService
 
                 case LaunchItemType.VsCommand:
                     // Special handling for debug commands
-                    if (item.Target.Equals("Debug.Start", StringComparison.OrdinalIgnoreCase))
+                    if (item.Target.Equals("Debug.Start", StringComparison.OrdinalIgnoreCase) ||
+                        item.Target.Equals("Debug.StartWithoutDebugging", StringComparison.OrdinalIgnoreCase))
                     {
-                        await ToggleDebugAsync();
+                        await ToggleDebugAsync(item.Target);
                     }
                     else
                     {
@@ -201,14 +202,14 @@ public sealed class LaunchService : ILaunchService
         }
     }
 
-    private async Task ToggleDebugAsync()
+    private async Task ToggleDebugAsync(string startCommand)
     {
         await ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
 
         var dte = await _package.GetServiceAsync(typeof(DTE)) as DTE2;
         if (dte == null)
         {
-            await VS.Commands.ExecuteAsync("Debug.Start");
+            await VS.Commands.ExecuteAsync(startCommand);
             return;
         }
 
@@ -221,8 +222,8 @@ public sealed class LaunchService : ILaunchService
         }
         else
         {
-            // Not debugging - start
-            await VS.Commands.ExecuteAsync("Debug.Start");
+            // Not debugging - start with the specified command
+            await VS.Commands.ExecuteAsync(startCommand);
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a new "Start Without Debugging" button to the default configuration (using `Debug.StartWithoutDebugging` VS command)
- Both debug buttons toggle to a stop icon/action when a debug session is active
- `DebugStateService` updates the icon and name for both buttons based on debugger state

Closes #9

## Test plan
- [ ] New installs show a "Start Without Debugging" button (with RunOutline icon) below the debug button
- [ ] Clicking it starts the project without the debugger attached
- [ ] While running, both debug buttons show stop icons
- [ ] Clicking either stop button stops the session
- [ ] After stopping, icons revert (Run for debug, RunOutline for start without debugging)
- [ ] Existing users with custom configs are unaffected (new button only in defaults)